### PR TITLE
Remove redundant add filter instruction

### DIFF
--- a/addons/godot-inheritance-dock/filter_menu.gd
+++ b/addons/godot-inheritance-dock/filter_menu.gd
@@ -95,8 +95,6 @@ func _set_save_disabled(p_disabled):
 ##### CONNECTIONS #####
 
 func _on_add_filter_button_pressed():
-	var item = FilterMenuItemScene.instance()
-	filter_vbox.add_child(item)
 	add_filter()
 	_update_filters()
 


### PR DESCRIPTION
Fixes #20. The add filter button event handler and the `add_filter()` function both contained the identical add filter logic. I assume `add_filter()` is supposed to be the intended place for instancing new filter menu items while the other one was a leftover.