### PR TITLE
Ignore CSV files

### DIFF
--- a/addons/godot-inheritance-dock/res_utility.gd
+++ b/addons/godot-inheritance-dock/res_utility.gd
@@ -8,7 +8,7 @@ extends Reference
 
 ##### CONSTANTS #####
 
-const REGEX_EXT_SCRIPT = "\\.gd|\\.vs|\\.cs|\\.gdns"
+const REGEX_EXT_SCRIPT = "\\.gd|\\.vs|\\.cs(?!v)|\\.gdns"
 const REGEX_EXT_SCENE = "\\.t?scn"
 const REGEX_EXT_RES = "\\.t?res"
 


### PR DESCRIPTION
Fixes #21. 

> .../res_utility.gd:115 - Invalid call. Nonexistent function 'get_base_script' in base 'TextFile'.

The regex still matches the `.cs` extension as a script type but won't falsely match `.csv` anymore and hence be spamming said error message.